### PR TITLE
Added tracker and handling of injections at same location.

### DIFF
--- a/src/memory/injection/asm/x64.cpp
+++ b/src/memory/injection/asm/x64.cpp
@@ -12,7 +12,7 @@ namespace mem  {
 namespace code {
 namespace x64  {
 
-
+ std::unordered_map<uint64_t, TrackChainInjection*> injected_locations;
 
 // Writes bytecode for the series of instructions to perform an absolute JMP r64 (using JMP %rax)
 //  and restore the register upon returning. Also overwrites remaining garbage bytecode with


### PR DESCRIPTION
Option to allow library to have multiple injections at same address.

Example usage:
``
inject_jmp_14b((void*)write_address, &npc_guard_check_exit, 2, &npc_guard_asm_check, true);
inject_jmp_14b(write_address, &main_dead_angle_injection_return, 0, &main_dead_angle_injection, true);
``

What happens in code:
 * Reach write_address
 * Jump to handler space
 * jump to injection 1
 * jump back to handler space
 * jump to injection 2
 * jump back to handler space
 * jump back to write_address

If chain_function isn't provided functionality is unchanged, besides the addition of a check for a previous injection at the same address.